### PR TITLE
Fix for avoid warning in php 5.6

### DIFF
--- a/php/conf.d/rezzza.ini
+++ b/php/conf.d/rezzza.ini
@@ -1,3 +1,5 @@
 ; global ini sets
 date.timezone = "UTC"
 memory_limit="2G"
+; see http://php.net/manual/fr/ini.core.php#ini.always-populate-raw-post-data
+always_populate_raw_post_data=-1


### PR DESCRIPTION
no problem as symfony no more use HTTP_RAW_POST_DATA
