### PR TITLE
aop configuration

### DIFF
--- a/php/conf.d/aop.ini
+++ b/php/conf.d/aop.ini
@@ -1,0 +1,1 @@
+extension=aop.so


### PR DESCRIPTION
I need to instantiate a php using AOP because of HTTP calls, so I can't only do 
`php -d "extension=aop.so"`

AOP need to be available on each php process.