### PR TITLE
Follow docker policy & switch to docker-ce

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,15 +1,13 @@
 #!/bin/sh
 set -e
 
-apt-cache madison docker-engine \
-    && sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION} \
+sudo sed -i -e 's/ edge/ edge test/' /etc/apt/sources.list.d/docker.list \
+    && sudo apt-get update \
+    && apt-cache madison docker-ce \
+    && sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=${DOCKER_VERSION} \
     && sudo rm /usr/local/bin/docker-compose \
     && curl -sL https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose \
     && chmod +x docker-compose \
     && sudo mv docker-compose /usr/local/bin \
-    && mkdir -p ~/docker-images \
-    && echo "DOCKER_OPTS=\"-g $HOME/docker-images $@\"\n" | sudo tee -a /etc/default/docker \
-    && sudo service docker restart \
     && docker version \
-    && docker-compose version \
-    && docker images
+    && docker-compose version


### PR DESCRIPTION
bye bye former docker-engine!

Also added the possibility to run ci with test versions of docker.